### PR TITLE
Add system clock syncing

### DIFF
--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1212,3 +1212,12 @@ handle_fw_switching() {
     fi
   fi
 }
+
+sync_clocks() {
+  echo "Waiting for system clock to be synced ..."
+  chronyc waitsync 10 0 0 5 &> /dev/null
+  if [[ $? -ne 0 ]]; then
+    print_warning "Failed to sync system clock with NTP server!"
+    print_warning "Some time critical tasks might fail!"
+  fi
+}

--- a/scripts/dasharo-deploy
+++ b/scripts/dasharo-deploy
@@ -458,6 +458,7 @@ update_ec() {
 update() {
   local _can_switch_to_heads="false"
 
+  sync_clocks
   check_if_ac
   error_check "Firmware update process interrupted on user request."
 


### PR DESCRIPTION
The clocks are being synced by chronyd.service, but it starts with a delay, which may cause some problems with unsynced clocks. So, sync clocks manually.

Solves issue https://github.com/Dasharo/dasharo-issues/issues/732.
Replaces PR https://github.com/Dasharo/meta-dts/pull/112 after scripts have been moved to separate repository.