### PR TITLE
make exports not overwrite existing values

### DIFF
--- a/include/dts-environment.sh
+++ b/include/dts-environment.sh
@@ -7,103 +7,103 @@
 # shellcheck disable=SC2034
 
 # Text colors:
-NORMAL='\033[0m'
-RED='\033[0;31m'
-YELLOW='\033[0;33m'
-GREEN='\033[0;32m'
-BLUE='\033[0;36m'
+NORMAL=${NORMAL:='\033[0m'}
+RED=${RED:='\033[0;31m'}
+YELLOW=${YELLOW:='\033[0;33m'}
+GREEN=${GREEN:='\033[0;32m'}
+BLUE=${BLUE:='\033[0;36m'}
 
 # DTS options:
-HCL_REPORT_OPT="1"
-DASHARO_FIRM_OPT="2"
-REST_FIRM_OPT="3"
-DES_KEYS_OPT="4"
-REBOOT_OPT_UP="R"
-REBOOT_OPT_LOW="$(echo $REBOOT_OPT_UP | awk '{print tolower($0)}')"
-POWEROFF_OPT_UP="P"
-POWEROFF_OPT_LOW="$(echo $POWEROFF_OPT_UP | awk '{print tolower($0)}')"
-SHELL_OPT_UP="S"
-SHELL_OPT_LOW="$(echo $SHELL_OPT_UP | awk '{print tolower($0)}')"
-SSH_OPT_UP="K"
-SSH_OPT_LOW="$(echo $SSH_OPT_UP | awk '{print tolower($0)}')"
+HCL_REPORT_OPT=${HCL_REPORT_OPT:="1"}
+DASHARO_FIRM_OPT=${DASHARO_FIRM_OPT:="2"}
+REST_FIRM_OPT=${REST_FIRM_OPT:="3"}
+DES_KEYS_OPT=${DES_KEYS_OPT:="4"}
+REBOOT_OPT_UP=${REBOOT_OPT_UP:="R"}
+REBOOT_OPT_LOW=${REBOOT_OPT_LOW:="$(echo $REBOOT_OPT_UP | awk '{print tolower($0)}')"}
+POWEROFF_OPT_UP=${POWEROFF_OPT_UP:="P"}
+POWEROFF_OPT_LOW=${POWEROFF_OPT_LOW:="$(echo $POWEROFF_OPT_UP | awk '{print tolower($0)}')"}
+SHELL_OPT_UP=${SHELL_OPT_UP:="S"}
+SHELL_OPT_LOW=${SHELL_OPT_LOW:="$(echo $SHELL_OPT_UP | awk '{print tolower($0)}')"}
+SSH_OPT_UP=${SSH_OPT_UP:="K"}
+SSH_OPT_LOW=${SSH_OPT_LOW:="$(echo $SSH_OPT_UP | awk '{print tolower($0)}')"}
 
-SYSTEM_VENDOR="$(dmidecode -s system-manufacturer)"
-SYSTEM_MODEL="$(dmidecode -s system-product-name)"
-BOARD_VENDOR="$(dmidecode -s baseboard-manufacturer)"
-BOARD_MODEL="$(dmidecode -s baseboard-product-name)"
-CPU_VERSION="$(dmidecode -s processor-version)"
-BIOS_VENDOR="$(dmidecode -s bios-vendor)"
-BIOS_VERSION="$(dmidecode -s bios-version)"
-DASHARO_VERSION="$(echo $BIOS_VERSION | cut -d ' ' -f 3 | tr -d 'v')"
-DASHARO_FLAVOR="$(echo $BIOS_VERSION | cut -d ' ' -f 1,2)"
+SYSTEM_VENDOR=${SYSTEM_VENDOR:="$(dmidecode -s system-manufacturer)"}
+SYSTEM_MODEL=${SYSTEM_MODEL:="$(dmidecode -s system-product-name)"}
+BOARD_VENDOR=${BOARD_VENDOR:="$(dmidecode -s baseboard-manufacturer)"}
+BOARD_MODEL=${BOARD_MODEL:="$(dmidecode -s baseboard-product-name)"}
+CPU_VERSION=${CPU_VERSION:="$(dmidecode -s processor-version)"}
+BIOS_VENDOR=${BIOS_VENDOR:="$(dmidecode -s bios-vendor)"}
+BIOS_VERSION=${BIOS_VERSION:="$(dmidecode -s bios-version)"}
+DASHARO_VERSION=${DASHARO_VERSION:="$(echo $BIOS_VERSION | cut -d ' ' -f 3 | tr -d 'v')"}
+DASHARO_FLAVOR=${DASHARO_FLAVOR:="$(echo $BIOS_VERSION | cut -d ' ' -f 1,2)"}
 
 # path to temporary files, created while deploying or updating Dasharo firmware
-BIOS_UPDATE_FILE="/tmp/biosupdate.rom"
-EC_UPDATE_FILE="/tmp/ecupdate.rom"
-BIOS_HASH_FILE="/tmp/bioshash.sha256"
-EC_HASH_FILE="/tmp/echash.sha256"
-BIOS_SIGN_FILE="/tmp/biossignature.sig"
-EC_SIGN_FILE="/tmp/ecsignature.sig"
-BIOS_UPDATE_CONFIG_FILE="/tmp/biosupdate_config"
-RESIGNED_BIOS_UPDATE_FILE="/tmp/biosupdate_resigned.rom"
-SYSTEM_UUID_FILE="/tmp/system_uuid.txt"
-SERIAL_NUMBER_FILE="/tmp/serial_number.txt"
+BIOS_UPDATE_FILE=${BIOS_UPDATE_FILE:="/tmp/biosupdate.rom"}
+EC_UPDATE_FILE=${EC_UPDATE_FILE:="/tmp/ecupdate.rom"}
+BIOS_HASH_FILE=${BIOS_HASH_FILE:="/tmp/bioshash.sha256"}
+EC_HASH_FILE=${EC_HASH_FILE:="/tmp/echash.sha256"}
+BIOS_SIGN_FILE=${BIOS_SIGN_FILE:="/tmp/biossignature.sig"}
+EC_SIGN_FILE=${EC_SIGN_FILE:="/tmp/ecsignature.sig"}
+BIOS_UPDATE_CONFIG_FILE=${BIOS_UPDATE_CONFIG_FILE:="/tmp/biosupdate_config"}
+RESIGNED_BIOS_UPDATE_FILE=${RESIGNED_BIOS_UPDATE_FILE:="/tmp/biosupdate_resigned.rom"}
+SYSTEM_UUID_FILE=${SYSTEM_UUID_FILE:="/tmp/system_uuid.txt"}
+SERIAL_NUMBER_FILE=${SERIAL_NUMBER_FILE:="/tmp/serial_number.txt"}
 
 # default value for flash chip related information
-FLASH_CHIP_SELECT=""
-FLASH_CHIP_SIZE=""
+FLASH_CHIP_SELECT=${FLASH_CHIP_SELECT:=""}
+FLASH_CHIP_SIZE=${FLASH_CHIP_SIZE:=""}
 
 # dasharo-deploy backup cmd related variables, do we still use and need this as
 # backup is placed in HCL?
-ROOT_DIR="/"
-FW_BACKUP_NAME="fw_backup"
-FW_BACKUP_DIR="${ROOT_DIR}${FW_BACKUP_NAME}"
-FW_BACKUP_TAR="${FW_BACKUP_DIR}.tar.gz"
-FW_BACKUP_TAR="$(echo "$FW_BACKUP_TAR" | sed 's/\ /_/g')"
+ROOT_DIR=${ROOT_DIR:="/"}
+FW_BACKUP_NAME=${FW_BACKUP_NAME:="fw_backup"}
+FW_BACKUP_DIR=${FW_BACKUP_DIR:="${ROOT_DIR}${FW_BACKUP_NAME}"}
+FW_BACKUP_TAR=${FW_BACKUP_TAR:="${FW_BACKUP_DIR}.tar.gz"}
+FW_BACKUP_TAR=${FW_BACKUP_TAR:="$(echo "$FW_BACKUP_TAR" | sed 's/\ /_/g')"}
 
 # path to system files
-ERR_LOG_FILE="/var/local/dts-err.log"
-FLASHROM_LOG_FILE="/var/local/flashrom.log"
-FLASH_INFO_FILE="/tmp/flash_info"
-OS_VERSION_FILE="/etc/os-release"
-KEYS_DIR="/tmp/devkeys"
+ERR_LOG_FILE=${ERR_LOG_FILE:="/var/local/dts-err.log"}
+FLASHROM_LOG_FILE=${FLASHROM_LOG_FILE:="/var/local/flashrom.log"}
+FLASH_INFO_FILE=${FLASH_INFO_FILE:="/tmp/flash_info"}
+OS_VERSION_FILE=${OS_VERSION_FILE:="/etc/os-release"}
+KEYS_DIR=${KEYS_DIR:="/tmp/devkeys"}
 
 # path to system commands
-CMD_POWEROFF="/sbin/poweroff"
-CMD_REBOOT="/sbin/reboot"
-CMD_SHELL="/bin/bash"
-CMD_DASHARO_HCL_REPORT="/usr/sbin/dasharo-hcl-report"
-CMD_NCMENU="/usr/sbin/novacustom_menu"
-CMD_DASHARO_DEPLOY="/usr/sbin/dasharo-deploy"
-CMD_CLOUD_LIST="/usr/sbin/cloud_list"
-CMD_EC_TRANSITION="/usr/sbin/ec_transition"
+CMD_POWEROFF=${CMD_POWEROFF:="/sbin/poweroff"}
+CMD_REBOOT=${CMD_REBOOT:="/sbin/reboot"}
+CMD_SHELL=${CMD_SHELL:="/bin/bash"}
+CMD_DASHARO_HCL_REPORT=${CMD_DASHARO_HCL_REPORT:="/usr/sbin/dasharo-hcl-report"}
+CMD_NCMENU=${CMD_NCMENU:="/usr/sbin/novacustom_menu"}
+CMD_DASHARO_DEPLOY=${CMD_DASHARO_DEPLOY:="/usr/sbin/dasharo-deploy"}
+CMD_CLOUD_LIST=${CMD_CLOUD_LIST:="/usr/sbin/cloud_list"}
+CMD_EC_TRANSITION=${CMD_EC_TRANSITION:="/usr/sbin/ec_transition"}
 
 # default values for flashrom programmer
-FLASHROM="flashrom"
-PROGRAMMER_BIOS="internal"
-PROGRAMMER_EC="ite_ec"
+FLASHROM=${FLASHROM:="flashrom"}
+PROGRAMMER_BIOS=${PROGRAMMER_BIOS:="internal"}
+PROGRAMMER_EC=${PROGRAMMER_EC:="ite_ec"}
 
-DASHARO_ECTOOL="dasharo_ectool"
+DASHARO_ECTOOL=${DASHARO_ECTOOL:="dasharo_ectool"}
 
 # variables defining Dasharo specific entries in DMI tables, used to check if
 # Dasharo FW is already installed
-DASHARO_VENDOR="3mdeb"
-DASHARO_NAME="Dasharo"
+DASHARO_VENDOR=${DASHARO_VENDOR:="3mdeb"}
+DASHARO_NAME=${DASHARO_NAME:="Dasharo"}
 
 # most the time one flash chipset will be detected, for other cases (like for
 # ASUS KGPE-D16) we will test the following list in check_flash_chip function
-FLASH_CHIP_LIST="W25Q64BV/W25Q64CV/W25Q64FV W25Q64JV-.Q W25Q128.V..M"
+FLASH_CHIP_LIST=${FLASH_CHIP_LIST:="W25Q64BV/W25Q64CV/W25Q64FV W25Q64JV-.Q W25Q128.V..M"}
 
 # Dasharo Supporters Entrance variables
-SE_credential_file="/etc/cloud-pass"
-FW_STORE_URL="${FW_STORE_URL_DEV:-https://dl.3mdeb.com/open-source-firmware/Dasharo}"
-FW_STORE_URL_DES="https://cloud.3mdeb.com/public.php/webdav"
-CLOUD_REQUEST="X-Requested-With: XMLHttpRequest"
+SE_credential_file=${SE_credential_file:="/etc/cloud-pass"}
+FW_STORE_URL=${FW_STORE_URL:="${FW_STORE_URL_DEV:-https://dl.3mdeb.com/open-source-firmware/Dasharo}"}
+FW_STORE_URL_DES=${FW_STORE_URL_DES:="https://cloud.3mdeb.com/public.php/webdav"}
+CLOUD_REQUEST=${CLOUD_REQUEST:="X-Requested-With: XMLHttpRequest"}
 
 ## base values
-BASE_CLOUDSEND_LOGS_URL="39d4biH4SkXD8Zm"
-BASE_CLOUDSEND_PASSWORD="1{\[\k6G"
-DEPLOY_REPORT="false"
+BASE_CLOUDSEND_LOGS_URL=${BASE_CLOUDSEND_LOGS_URL:="39d4biH4SkXD8Zm"}
+BASE_CLOUDSEND_PASSWORD=${BASE_CLOUDSEND_PASSWORD:="1{\[\k6G"}
+DEPLOY_REPORT=${DEPLOY_REPORT:="false"}
 
 # set custom localization for PGP keys
 if [ -d /home/root/.dasharo-gnupg ]; then


### PR DESCRIPTION
This is useful for tests.

If we export some mock values of for example `BIOS_VENDOR`, we do not want them to be overwritten during the test execution.

Declaring the variables like this makes it so that they are not automatically overwritten.