### PR TITLE
fix Intel regions backup

### DIFF
--- a/reports/dasharo-hcl-report
+++ b/reports/dasharo-hcl-report
@@ -178,23 +178,23 @@ printf '################################                                   |\r'
 # echo "Trying to read firmware image with flashrom..."
 # Some regions may be not available so we need to use specific regions to read
 check_intel_regions
-if [ $BOARD_HAS_FD_REGION -eq 0 ]; then
-  # No descriptor, probably safe to read everything
-  FLASHROM_ADD_OPT_READ=" "
-else
+if [ $BOARD_HAS_FD_REGION -eq 1 ]; then
   # Use safe defaults. Descriptor may contain additional regions not detected
   # by flashrom and will return failure when attempted to be read. BIOS and
   # Flash descriptor regions should always be readable. If not, then we have
   # some ugly case, hard to deal with.
   FLASHROM_ADD_OPT_READ="--ifd -i fd -i bios"
-  if [ $BOARD_HAS_ME_REGION -eq 0 ] && [ $BOARD_ME_REGION_LOCKED -ne 0 ]; then
+  if [ $BOARD_HAS_ME_REGION -eq 1 ] && [ $BOARD_ME_REGION_LOCKED -eq 0 ]; then
     # ME region is not locked, read it as well
     FLASHROM_ADD_OPT_READ+=" -i me"
   fi
-  if [ $BOARD_HAS_GBE_REGION -eq 0 ] && [ $BOARD_GBE_REGION_LOCKED -ne 0 ]; then
+  if [ $BOARD_HAS_GBE_REGION -eq 1 ] && [ $BOARD_GBE_REGION_LOCKED -eq 0 ]; then
     # GBE region is present and not locked, read it as well
     FLASHROM_ADD_OPT_READ+=" -i gbe"
   fi
+  else
+      # No descriptor, probably safe to read everything
+      FLASHROM_ADD_OPT_READ=""
 fi
 
 $FLASHROM -V -p internal:laptop=force_I_want_a_brick ${FLASH_CHIP_SELECT} -r logs/rom.bin ${FLASHROM_ADD_OPT_READ} > logs/flashrom_read.log 2> logs/flashrom_read.err.log

--- a/scripts/dasharo-deploy
+++ b/scripts/dasharo-deploy
@@ -161,17 +161,17 @@ backup() {
   echo "Backing up BIOS firmware and store it locally..."
   echo "Remember that firmware is also backed up in HCL report."
   check_intel_regions
-  if [ $BOARD_HAS_FD_REGION -ne 0 ]; then
+  if [ $BOARD_HAS_FD_REGION -eq 1 ]; then
     # Use safe defaults. Descriptor may contain additional regions not detected
     # by flashrom and will return failure when attempted to be read. BIOS and
     # Flash descriptor regions should always be readable. If not, then we have
     # some ugly case, hard to deal with.
     FLASHROM_ADD_OPT_READ="--ifd -i fd -i bios"
-    if [ $BOARD_HAS_ME_REGION -ne 0 ] && [ $BOARD_ME_REGION_LOCKED -eq 0 ]; then
+    if [ $BOARD_HAS_ME_REGION -eq 1 ] && [ $BOARD_ME_REGION_LOCKED -eq 0 ]; then
       # ME region is not locked, read it as well
       FLASHROM_ADD_OPT_READ+=" -i me"
     fi
-    if [ $BOARD_HAS_GBE_REGION -ne 0 ] && [ $BOARD_GBE_REGION_LOCKED -eq 0 ]; then
+    if [ $BOARD_HAS_GBE_REGION -eq 1 ] && [ $BOARD_GBE_REGION_LOCKED -eq 0 ]; then
       # GBE region is present and not locked, read it as well
       FLASHROM_ADD_OPT_READ+=" -i gbe"
     fi


### PR DESCRIPTION
We have detected that the ME and IGB regions are not backed up on MTL laptops (should affect other hw as well) due to the mismatch in this detection logic.

Another issue is why we have two functions doing the same thing, but this can be resolved by a followup commits.