### PR TITLE
Always log xtrace to file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ install:
 	install -m 0755 scripts/dts $(DESTDIR)$(SBINDIR)
 	install -m 0755 scripts/dts-boot $(DESTDIR)$(SBINDIR)
 	install -m 0755 scripts/ec_transition $(DESTDIR)$(SBINDIR)
+	install -m 0755 scripts/logging $(DESTDIR)$(SBINDIR)/logging
 
 	install -m 0755 reports/dasharo-hcl-report $(DESTDIR)$(SBINDIR)
 	install -m 0755 reports/touchpad-info $(DESTDIR)$(SBINDIR)

--- a/include/dts-environment.sh
+++ b/include/dts-environment.sh
@@ -87,7 +87,6 @@ FW_BACKUP_TAR="${FW_BACKUP_DIR}.tar.gz"
 FW_BACKUP_TAR="$(echo "$FW_BACKUP_TAR" | sed 's/\ /_/g')"
 
 # Paths to system files
-ERR_LOG_FILE="/var/local/dts-err.log"
 FLASHROM_LOG_FILE="/var/local/flashrom.log"
 FLASH_INFO_FILE="/tmp/flash_info"
 OS_VERSION_FILE="/etc/os-release"

--- a/include/dts-environment.sh
+++ b/include/dts-environment.sh
@@ -50,8 +50,6 @@ SSH_OPT_UP="K"
 SSH_OPT_LOW="$(echo $SSH_OPT_UP | awk '{print tolower($0)}')"
 SEND_LOGS_OPT="L"
 SEND_LOGS_OPT_LOW="$(echo $SEND_LOGS_OPT | awk '{print tolower($0)}')"
-VERBOSE_OPT="V"
-VERBOSE_OPT_LOW="$(echo $VERBOSE_OPT | awk '{print tolower($0)}')"
 
 # Hardware variables:
 SYSTEM_VENDOR="$($DMIDECODE dump_var_mock -s system-manufacturer)"

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -83,8 +83,8 @@ check_if_ac() {
 fum_exit() {
     if [ "$FUM" == "fum" ]; then
       print_error "Update cannot be performed"
-      print_warning "Starting bash session - please make sure you get logs from\r
-      \r$ERR_LOG_FILE_REALPATH and $FLASHROM_LOG_FILE; then you can poweroff the platform"
+      print_warning "Starting bash session"
+      send_dts_logs ask
       /bin/bash
     fi
 }

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1415,7 +1415,7 @@ main_menu_options(){
           ${CMD_DASHARO_DEPLOY} install
           result=$?
           if [ "$result" -ne 0 ] && [ "$result" -ne 2 ]; then
-            send_dts_logs ask
+            send_dts_logs ask && return 0
           fi
         fi
       else
@@ -1447,7 +1447,7 @@ main_menu_options(){
         ${CMD_DASHARO_DEPLOY} update
         result=$?
         if [ "$result" -ne 0 ] && [ "$result" -ne 2 ]; then
-          send_dts_logs ask
+          send_dts_logs ask && return 0
         fi
       fi
       read -p "Press Enter to continue."
@@ -1461,7 +1461,7 @@ main_menu_options(){
 
       if check_if_dasharo; then
         if ! ${CMD_DASHARO_DEPLOY} restore; then
-          send_dts_logs ask
+          send_dts_logs ask && return 0
         fi
       fi
       read -p "Press Enter to continue."

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1651,7 +1651,6 @@ send_dts_logs() {
       echo "Failed to send logs to the cloud"
       return 1
     fi
-    unset SEND_LOGS_ACTIVE
   fi
   if [ "$1" = "ask" ]; then
     read -p "Press Enter to continue."

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1212,7 +1212,7 @@ handle_fw_switching() {
 
 sync_clocks() {
   echo "Waiting for system clock to be synced ..."
-  chronyc waitsync 10 0 0 5 >/dev/null 2>>ERR_LOG_FILE
+  chronyc waitsync 10 0 0 5 >/dev/null 2>>"$ERR_LOG_FILE"
   if [[ $? -ne 0 ]]; then
     print_warning "Failed to sync system clock with NTP server!"
     print_warning "Some time critical tasks might fail!"
@@ -1767,7 +1767,7 @@ check_if_intel() {
 ask_for_confirmation() {
   local text="$1"
 
-  read -p "$1 [N/y]: "
+  read -p "$text [N/y]: "
   case ${REPLY} in
     yes|y|Y|Yes|YES)
       return 0

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -889,7 +889,7 @@ check_blobs_in_binary() {
 
   # If there is no descriptor, there is no ME as well, so skip the check
   if [ $BOARD_HAS_FD_REGION -ne 0 ]; then
-    ME_OFFSET=$($IFDTOOL check_blobs_in_binary_mock -d $1 2> /dev/null | grep "Flash Region 2 (Intel ME):" | sed 's/Flash Region 2 (Intel ME)\://' | awk '{print $1;}')
+    ME_OFFSET=$($IFDTOOL check_blobs_in_binary_mock -d $1 2>>"$ERR_LOG_FILE" | grep "Flash Region 2 (Intel ME):" | sed 's/Flash Region 2 (Intel ME)\://' | awk '{print $1;}')
     # Check for IFD signature at offset 0 (old descriptors)
     if [ "$(tail -c +0 $1|head -c 4|xxd -ps)" == "5aa5f00f" ]; then
       BINARY_HAS_FD=1
@@ -1003,8 +1003,8 @@ set_flashrom_update_params() {
   echo "Checking flash layout."
   $FLASHROM read_flash_layout_mock -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} ${FLASHROM_ADD_OPT_UPDATE} -r $BIOS_DUMP_FILE > /dev/null 2>&1
   if [ $? -eq 0 ] && [ -f "$BIOS_DUMP_FILE" ]; then
-    BOARD_FMAP_LAYOUT=$($CBFSTOOL layout_mock $BIOS_DUMP_FILE layout -w 2> /dev/null)
-    BINARY_FMAP_LAYOUT=$($CBFSTOOL layout_mock $1 layout -w 2> /dev/null)
+    BOARD_FMAP_LAYOUT=$($CBFSTOOL layout_mock $BIOS_DUMP_FILE layout -w 2>>"$ERR_LOG_FILE")
+    BINARY_FMAP_LAYOUT=$($CBFSTOOL layout_mock $1 layout -w 2>>"$ERR_LOG_FILE")
     diff <(echo "$BOARD_FMAP_LAYOUT") <(echo "$BINARY_FMAP_LAYOUT") > /dev/null 2>&1
     # If layout is identical, perform standard update using FMAP only
     if [ $? -eq 0 ]; then
@@ -1208,7 +1208,7 @@ handle_fw_switching() {
 
 sync_clocks() {
   echo "Waiting for system clock to be synced ..."
-  chronyc waitsync 10 0 0 5 &> /dev/null
+  chronyc waitsync 10 0 0 5 >/dev/null 2>>ERR_LOG_FILE
   if [[ $? -ne 0 ]]; then
     print_warning "Failed to sync system clock with NTP server!"
     print_warning "Some time critical tasks might fail!"

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1231,6 +1231,8 @@ You can find more info about HCL in docs.dasharo.com/glossary\r"
 }
 
 show_ram_inf() {
+  # trace logging is quite slow due to timestamp (calls 'date')
+  stop_trace_logging
   # Get the data:
   local data=""
   data=$($DMIDECODE)
@@ -1273,6 +1275,7 @@ show_ram_inf() {
   for entry in "${memory_devices_array[@]}"; do
     echo -e "${BLUE}**${YELLOW}    RAM ${entry}"
   done
+  start_trace_logging
 }
 
 show_header() {

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -91,12 +91,16 @@ fum_exit() {
 
 error_exit() {
   _error_msg="$1"
+  local exit_code=1
+  if [ "$#" -eq 2 ]; then
+     exit_code=$2
+  fi
   if [ -n "$_error_msg" ]; then
     # Avoid printing empty line if no message was passed
     print_error "$_error_msg"
   fi
   fum_exit
-  exit 1
+  exit $exit_code
 }
 
 error_check() {
@@ -1355,6 +1359,7 @@ show_main_menu() {
 
 main_menu_options(){
   local OPTION=$1
+  local result
 
   case ${OPTION} in
     "${HCL_REPORT_OPT}")
@@ -1407,7 +1412,9 @@ main_menu_options(){
         fi
 
         if [ -n "${LOGS_SENT}" ]; then
-          if ! ${CMD_DASHARO_DEPLOY} install; then
+          ${CMD_DASHARO_DEPLOY} install
+          result=$?
+          if [ "$result" -ne 0 ] && [ "$result" -ne 2 ]; then
             send_dts_logs ask
           fi
         fi
@@ -1437,7 +1444,9 @@ main_menu_options(){
         fi
 
         # Use regular update process for everything else
-        if ! ${CMD_DASHARO_DEPLOY} update; then
+        ${CMD_DASHARO_DEPLOY} update;
+        result=$?
+        if [ "$result" -ne 0 ] && [ "$result" -ne 2 ]; then
           send_dts_logs ask
         fi
       fi

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1444,7 +1444,7 @@ main_menu_options(){
         fi
 
         # Use regular update process for everything else
-        ${CMD_DASHARO_DEPLOY} update;
+        ${CMD_DASHARO_DEPLOY} update
         result=$?
         if [ "$result" -ne 0 ] && [ "$result" -ne 2 ]; then
           send_dts_logs ask
@@ -1625,9 +1625,9 @@ send_dts_logs() {
     log_dir+="_${uuid}_$(date +'%Y_%m_%d_%H_%M_%S_%N')"
     log_dir="${log_dir// /_}"
     log_dir="${log_dir//\//_}"
-    log_dir="/tmp/${log_dir}"
+    log_dir="${TMP_LOG_DIR}/${log_dir}"
 
-    mkdir $log_dir
+    mkdir -p $log_dir
     cp ${DTS_LOG_FILE} $log_dir
     cp ${DTS_VERBOSE_LOG_FILE} $log_dir
 
@@ -1767,13 +1767,16 @@ check_if_intel() {
 ask_for_confirmation() {
   local text="$1"
 
-  read -p "$text [N/y]: "
-  case ${REPLY} in
-    yes|y|Y|Yes|YES)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  while read -p "$text [n/y]: "; do
+    case ${REPLY} in
+      y|Y|yes|Yes|YES)
+        return 0
+        ;;
+      n|N|no|No|NO)
+        return 1
+        ;;
+      *)
+        ;;
+    esac
+  done
 }

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1629,7 +1629,7 @@ send_dts_logs() {
     if [ -f ${FLASHROM_LOG_FILE} ]; then
       cp ${FLASHROM_LOG_FILE} $log_dir
     fi
-    tar czf "${log_dir}.tar.gz" $log_dir
+    tar czf "${log_dir}.tar.gz" -C "$(dirname "$log_dir")" "$(basename "$log_dir")"
 
     FULL_DTS_URL="https://cloud.3mdeb.com/index.php/s/"${BASE_DTS_LOGS_URL}
 

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1405,7 +1405,9 @@ main_menu_options(){
         fi
 
         if [ -n "${LOGS_SENT}" ]; then
-          ${CMD_DASHARO_DEPLOY} install
+          if ! ${CMD_DASHARO_DEPLOY} install; then
+            send_dts_logs
+          fi
         fi
       else
         # TODO: This should be placed in dasharo-deploy:
@@ -1433,7 +1435,9 @@ main_menu_options(){
         fi
 
         # Use regular update process for everything else
-        ${CMD_DASHARO_DEPLOY} update
+        if ! ${CMD_DASHARO_DEPLOY} update; then
+          send_dts_logs
+        fi
       fi
       read -p "Press Enter to continue."
 
@@ -1445,7 +1449,9 @@ main_menu_options(){
       [ "${SYSTEM_VENDOR}" = "QEMU" ] || [ "${SYSTEM_VENDOR}" = "Emulation" ] && return 0
 
       if check_if_dasharo; then
-        ${CMD_DASHARO_DEPLOY} restore
+        if ! ${CMD_DASHARO_DEPLOY} restore; then
+          send_dts_logs
+        fi
       fi
       read -p "Press Enter to continue."
 

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -84,7 +84,7 @@ fum_exit() {
     if [ "$FUM" == "fum" ]; then
       print_error "Update cannot be performed"
       print_warning "Starting bash session - please make sure you get logs from\r
-      \r$ERR_LOG_FILE and $FLASHROM_LOG_FILE; then you can poweroff the platform"
+      \r$ERR_LOG_FILE_REALPATH and $FLASHROM_LOG_FILE; then you can poweroff the platform"
       /bin/bash
     fi
 }
@@ -1561,7 +1561,7 @@ footer_options(){
       send_dts_logs
       stop_logging
       ${CMD_SHELL}
-      start_logging "$DTS_LOG_FILE"
+      start_logging
 
       # If in submenu before going to shell - return to main menu after exiting
       # shell:
@@ -1608,8 +1608,8 @@ send_dts_logs(){
     cp ${DTS_LOG_FILE} $log_dir
     cp ${DTS_VERBOSE_LOG_FILE} $log_dir
 
-    if [ -f ${ERR_LOG_FILE} ]; then
-      cp ${ERR_LOG_FILE} $log_dir
+    if [ -f ${ERR_LOG_FILE_REALPATH} ]; then
+      cp ${ERR_LOG_FILE_REALPATH} $log_dir
     fi
 
     if [ -f ${FLASHROM_LOG_FILE} ]; then

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1231,7 +1231,9 @@ You can find more info about HCL in docs.dasharo.com/glossary\r"
 }
 
 show_ram_inf() {
-  # trace logging is quite slow due to timestamp (calls 'date')
+  # Trace logging is quite slow due to creating timestamp for each line
+  # (calls 'date'). In QEMU this function results in 650 trace lines
+  # out of 800 for every UI refresh, which is noticeable
   stop_trace_logging
   # Get the data:
   local data=""

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1527,11 +1527,6 @@ show_footer(){
   else
     echo -e "${RED}${SEND_LOGS_OPT}${NORMAL} to enable sending DTS logs ${NORMAL}"
   fi
-  if [ "${VERBOSE_ACTIVE}" == "true" ]; then
-    echo -ne "${RED}${VERBOSE_OPT}${NORMAL} to disable verbose mode ${NORMAL}"
-  else
-    echo -ne "${RED}${VERBOSE_OPT}${NORMAL} to enable verbose mode ${NORMAL}"
-  fi
   echo -ne "${YELLOW}\nEnter an option:${NORMAL}"
 }
 
@@ -1561,8 +1556,9 @@ footer_options(){
       echo "Entering shell, to leave type exit and press Enter or press LCtrl+D"
       echo ""
       send_dts_logs
-      set_verbose "false"
+      stop_logging
       ${CMD_SHELL}
+      start_logging "$DTS_LOG_FILE"
 
       # If in submenu before going to shell - return to main menu after exiting
       # shell:
@@ -1581,13 +1577,6 @@ footer_options(){
         unset SEND_LOGS_ACTIVE
       else
         export SEND_LOGS_ACTIVE="true"
-      fi
-      ;;
-    "${VERBOSE_OPT}" | "${VERBOSE_OPT_LOW}")
-      if [ "${VERBOSE_ACTIVE}" == "true" ]; then
-        set_verbose "false"
-      else
-        set_verbose "true"
       fi
       ;;
   esac
@@ -1614,6 +1603,7 @@ send_dts_logs(){
 
     mkdir $log_dir
     cp ${DTS_LOG_FILE} $log_dir
+    cp ${DTS_VERBOSE_LOG_FILE} $log_dir
 
     if [ -f ${ERR_LOG_FILE} ]; then
       cp ${ERR_LOG_FILE} $log_dir
@@ -1742,24 +1732,5 @@ check_if_intel() {
   cpu_vendor=$(cat /proc/cpuinfo | grep "vendor_id" | head -n 1 | sed 's/.*: //')
   if [ $cpu_vendor == "GenuineIntel" ]; then
     return 0
-  fi
-}
-
-set_verbose() {
-  if [ $1 == "true" ]; then
-    VERBOSE_ACTIVE="true"
-    CMD_DASHARO_DEPLOY="/usr/bin/env bash -x $CMD_DASHARO_DEPLOY"
-    CMD_DASHARO_HCL_REPORT="/usr/bin/env bash -x $CMD_DASHARO_HCL_REPORT"
-    CMD_EC_TRANSITION="/usr/bin/env bash -x $CMD_EC_TRANSITION"
-    CMD_CLOUD_LIST="/usr/bin/env bash -x $CMD_CLOUD_LIST"
-    set -x
-  elif [ $1 == "false" ]; then
-    unset VERBOSE_ACTIVE
-    # Remove the -x option
-    CMD_DASHARO_DEPLOY=$(echo $CMD_DASHARO_DEPLOY | sed 's|^/usr/bin/env bash -x ||')
-    CMD_DASHARO_HCL_REPORT=$(echo $CMD_DASHARO_HCL_REPORT | sed 's|^/usr/bin/env bash -x ||')
-    CMD_EC_TRANSITION=$(echo $CMD_EC_TRANSITION | sed 's|^/usr/bin/env bash -x ||')
-    CMD_CLOUD_LIST=$(echo $CMD_CLOUD_LIST | sed 's|^/usr/bin/env bash -x ||')
-    set +x
   fi
 }

--- a/include/dts-subscription.sh
+++ b/include/dts-subscription.sh
@@ -44,22 +44,22 @@ check_for_dasharo_firmware() {
   # Check for firmware binaries:
   if wait_for_network_connection; then
     if [ -n "$BIOS_LINK_DPP" ]; then
-      _check_dwn_req_resp_uefi=$(curl -L -I -s -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP" -o /dev/null -w "%{http_code}")
+      _check_dwn_req_resp_uefi=$(curl -L -I -s -S -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP" -o /dev/null -w "%{http_code}" 2>>"$ERR_LOG_FILE")
     fi
 
     if [ -n "$BIOS_LINK_DPP_CAP" ]; then
-      _check_dwn_req_resp_uefi_cap=$(curl -L -I -s -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_CAP" -o /dev/null -w "%{http_code}")
+      _check_dwn_req_resp_uefi_cap=$(curl -L -I -s -S -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_CAP" -o /dev/null -w "%{http_code}" 2>>"$ERR_LOG_FILE")
     fi
 
     if [ -n "$HEADS_LINK_DPP" ]; then
-      _check_dwn_req_resp_heads=$(curl -L -I -s -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$HEADS_LINK_DPP" -o /dev/null -w "%{http_code}")
+      _check_dwn_req_resp_heads=$(curl -L -I -s -S -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$HEADS_LINK_DPP" -o /dev/null -w "%{http_code}" 2>>"$ERR_LOG_FILE")
     fi
 
     if [ -n "$BIOS_LINK_DPP_SEABIOS" ]; then
-      _check_dwn_req_resp_seabios=$(curl -L -I -s -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_SEABIOS" -o /dev/null -w "%{http_code}")
+      _check_dwn_req_resp_seabios=$(curl -L -I -s -S -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_SEABIOS" -o /dev/null -w "%{http_code}" 2>>"$ERR_LOG_FILE")
     fi
 
-    _check_logs_req_resp=$(curl -L -I -s -f -H "$CLOUD_REQUEST" "$TEST_LOGS_URL" -o /dev/null -w "%{http_code}")
+    _check_logs_req_resp=$(curl -L -I -s -S -f -H "$CLOUD_REQUEST" "$TEST_LOGS_URL" -o /dev/null -w "%{http_code}" 2>>"$ERR_LOG_FILE")
 
     # Return 0 if any of Dasharo Firmware binaries is available:
     if [ ${_check_dwn_req_resp_uefi} -eq 200 ] || [ ${_check_dwn_req_resp_uefi_cap} -eq 200 ] || [ ${_check_dwn_req_resp_heads} -eq 200 ] || [ ${_check_dwn_req_resp_seabios} -eq 200 ]; then

--- a/include/hal/dts-hal.sh
+++ b/include/hal/dts-hal.sh
@@ -144,7 +144,7 @@ tool_wrapper(){
 check_for_opensource_firmware()
 {
   echo "Checking for Open Source Embedded Controller firmware..."
-  $DASHARO_ECTOOL check_for_opensource_firm_mock info > /dev/null 2>&1
+  $DASHARO_ECTOOL check_for_opensource_firm_mock info > /dev/null 2>>"$ERR_LOG_FILE"
 
   return $?
 }
@@ -190,7 +190,7 @@ check_me_op_mode(){
 # Checks ME Current Operation Mode at offset 0x40 bits 19:16:
   local _mode
 
-  _mode="$($SETPCI check_me_op_mode_mock -s 00:16.0 42.B 2> /dev/null | cut -c2-)"
+  _mode="$($SETPCI check_me_op_mode_mock -s 00:16.0 42.B 2>>"$ERR_LOG_FILE" | cut -c2-)"
 
   echo "$_mode"
 

--- a/reports/dasharo-hcl-report
+++ b/reports/dasharo-hcl-report
@@ -219,10 +219,10 @@ printf '####################################                               |\r'
 
 # echo "Decompiling ACPI tables..."
 mkdir -p logs/acpi
-if pushd logs/acpi &> /dev/null; then
+if pushd logs/acpi >/dev/null 2>>"$ERR_LOG_FILE"; then
   acpixtract -a ../acpidump.log >/dev/null 2>>"$ERR_LOG_FILE"
   iasl -d ./*.dat >/dev/null 2>>"$ERR_LOG_FILE"
-  popd &> /dev/null || return 1
+  popd >/dev/null 2>>"$ERR_LOG_FILE" || return 1
 fi
 update_result "ACPI tables" 0 UNKNOWN
 printf '######################################                             |\r'
@@ -325,7 +325,7 @@ fi
 # warning:
 # shellcheck disable=SC2046
 MAC_ADDR=`cat /sys/class/net/$(ip route show default | head -1 | awk '/default/ {print $5}')/address`
-grep -rl "${MAC_ADDR}" logs > /dev/null && grep -rl "${MAC_ADDR}" logs | xargs sed -i 's/'${MAC_ADDR}'/MAC ADDRESS REMOVED/g'
+grep -rl "${MAC_ADDR}" logs >/dev/null && grep -rl "${MAC_ADDR}" logs | xargs sed -i 's/'${MAC_ADDR}'/MAC ADDRESS REMOVED/g'
 tar -zcf "$filename.tar.gz" logs/*
 rm -rf logs
 

--- a/reports/dasharo-hcl-report
+++ b/reports/dasharo-hcl-report
@@ -220,8 +220,8 @@ printf '####################################                               |\r'
 # echo "Decompiling ACPI tables..."
 mkdir -p logs/acpi
 if pushd logs/acpi &> /dev/null; then
-  acpixtract -a ../acpidump.log &>/dev/null
-  iasl -d ./*.dat &>/dev/null
+  acpixtract -a ../acpidump.log >/dev/null 2>>"$ERR_LOG_FILE"
+  iasl -d ./*.dat >/dev/null 2>>"$ERR_LOG_FILE"
   popd &> /dev/null || return 1
 fi
 update_result "ACPI tables" 0 UNKNOWN

--- a/scripts/cloud_list
+++ b/scripts/cloud_list
@@ -30,7 +30,7 @@ CLOUD_REQUEST="X-Requested-With: XMLHttpRequest"
 
 tmpURL="https://cloud.3mdeb.com/public.php/webdav/"
 
-curl -L -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" -X PROPFIND "$tmpURL" -o "$TMP_RESPONSE"
+curl -L -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" -X PROPFIND "$tmpURL" -o "$TMP_RESPONSE" 2>>"$ERR_LOG_FILE"
 error_check "Cannot access list of files on cloud."
 
 # parse response
@@ -53,7 +53,7 @@ HCL_REPORT_NAME=$(cat $TMP_LIST | grep -m1 $HW_UUID)
 
 # download HCL report
 tmpURL="https://cloud.3mdeb.com/public.php/webdav/$HCL_REPORT_NAME"
-curl -L -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" -X GET "$tmpURL" -o /$HCL_REPORT_NAME
+curl -L -f -u "$USER_DETAILS" -H "$CLOUD_REQUEST" -X GET "$tmpURL" -o /$HCL_REPORT_NAME 2>>"$ERR_LOG_FILE"
 if [ -f /$HCL_REPORT_NAME ]; then
   echo "Report downloaded"
 else

--- a/scripts/dasharo-deploy
+++ b/scripts/dasharo-deploy
@@ -994,7 +994,7 @@ update_workflow() {
   else
     compare_versions $DASHARO_VERSION $UPDATE_VERSION
     if [ $? -ne 1 ]; then
-      error_exit "No update available for your machine"
+      error_exit "No update available for your machine" 2
     fi
   fi
 

--- a/scripts/dasharo-deploy
+++ b/scripts/dasharo-deploy
@@ -80,7 +80,7 @@ check_for_firmware_access() {
       # This firmware type require user to provide creds:
       [ "$DPP_IS_LOGGED" == "true" ] || return 1
 
-      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP" -o /dev/null
+      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP" -o /dev/null 2>>"$ERR_LOG_FILE"
 
       [ $? -ne 0 ] && return 1
       ;;
@@ -88,7 +88,7 @@ check_for_firmware_access() {
       # This firmware type require user to provide creds:
       [ "$DPP_IS_LOGGED" == "true" ] || return 1
 
-      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_CAP" -o /dev/null
+      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_CAP" -o /dev/null 2>>"$ERR_LOG_FILE"
 
       [ $? -ne 0 ] && return 1
       ;;
@@ -96,7 +96,7 @@ check_for_firmware_access() {
       # This firmware type require user to provide creds:
       [ "$DPP_IS_LOGGED" == "true" ] || return 1
 
-      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_SEABIOS" -o /dev/null
+      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$BIOS_LINK_DPP_SEABIOS" -o /dev/null 2>>"$ERR_LOG_FILE"
 
       [ $? -ne 0 ] && return 1
       ;;
@@ -104,7 +104,7 @@ check_for_firmware_access() {
       # This firmware type require user to provide creds:
       [ "$DPP_IS_LOGGED" == "true" ] || return 1
 
-      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$HEADS_LINK_DPP" -o /dev/null
+      curl -sfI -u "$USER_DETAILS" -H "$CLOUD_REQUEST" "$HEADS_LINK_DPP" -o /dev/null 2>>"$ERR_LOG_FILE"
 
       [ $? -ne 0 ] && return 1
       ;;
@@ -517,7 +517,7 @@ romhole_migration() {
         return
       fi
     else
-      dd if=/tmp/rom.bin of=/tmp/romhole.bin skip=$((0x17C0000)) bs=128K count=1 iflag=skip_bytes > /dev/null 2>&1
+      dd if=/tmp/rom.bin of=/tmp/romhole.bin skip=$((0x17C0000)) bs=128K count=1 iflag=skip_bytes >/dev/null 2>>"$ERR_LOG_FILE"
     fi
 
     $CBFSTOOL "$BIOS_UPDATE_FILE" write -r ROMHOLE -f /tmp/romhole.bin -u 2>>"$ERR_LOG_FILE"
@@ -601,10 +601,10 @@ check_vboot_keys() {
       FLASHROM_ADD_OPT_READ="--ifd -i bios"
     fi
     echo "Checking vboot keys."
-    $FLASHROM read_firm_mock -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} ${FLASHROM_ADD_OPT_READ} -r $BIOS_DUMP_FILE > /dev/null 2>/dev/null
+    $FLASHROM read_firm_mock -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} ${FLASHROM_ADD_OPT_READ} -r $BIOS_DUMP_FILE >/dev/null 2>>"$ERR_LOG_FILE"
     if [ $? -eq 0 ] && [ -f $BIOS_DUMP_FILE ]; then
       FLASH_KEYS=$(CBFSTOOL=$(which cbfstool) $FUTILITY dump_vboot_keys show $BIOS_DUMP_FILE | grep -i 'key sha1sum')
-      diff <(echo "$BINARY_KEYS") <(echo "$FLASH_KEYS") > /dev/null 2>&1
+      diff <(echo "$BINARY_KEYS") <(echo "$FLASH_KEYS") >/dev/null 2>>"$ERR_LOG_FILE"
       # If keys are different we must additionally flash at least GBB region as well
       if [ $? -ne 0 ]; then
         FLASHROM_ADD_OPT_UPDATE+=" -i GBB"

--- a/scripts/dasharo-deploy
+++ b/scripts/dasharo-deploy
@@ -511,7 +511,7 @@ romhole_migration() {
     if check_if_dasharo; then
       $CBFSTOOL layout_mock /tmp/rom.bin layout -w | grep -q "ROMHOLE" || return
       # This one is rather unlikely to fail, but just in case print a warning
-      $CBFSTOOL read_romhole_mock /tmp/rom.bin read -r ROMHOLE -f /tmp/romhole.bin 2> /dev/null
+      $CBFSTOOL read_romhole_mock /tmp/rom.bin read -r ROMHOLE -f /tmp/romhole.bin 2>>"$ERR_LOG_FILE"
       if [ $? -ne 0 ]; then
         print_warning "Failed to migrate MSI ROMHOLE, your platform's unique SMBIOS/DMI data may be lost"
         return
@@ -520,7 +520,7 @@ romhole_migration() {
       dd if=/tmp/rom.bin of=/tmp/romhole.bin skip=$((0x17C0000)) bs=128K count=1 iflag=skip_bytes > /dev/null 2>&1
     fi
 
-    $CBFSTOOL "$BIOS_UPDATE_FILE" write -r ROMHOLE -f /tmp/romhole.bin -u 2> /dev/null
+    $CBFSTOOL "$BIOS_UPDATE_FILE" write -r ROMHOLE -f /tmp/romhole.bin -u 2>>"$ERR_LOG_FILE"
 }
 
 smbios_migration() {

--- a/scripts/dts-boot
+++ b/scripts/dts-boot
@@ -19,11 +19,13 @@ export DTS_VERBOSE_LOG_FILE
 export ERR_LOG_FILE
 export SHELLOPTS
 
+TMP_LOG_DIR="/tmp/logs"
+mkdir -p "$TMP_LOG_DIR"
 # $ERR_LOG_FILE is fd that can only be written to: '>()'. To copy logs
 # we need underlying file that can be copied
 ERR_LOG_FILE_REALPATH="/var/local/dts-err_$(basename "$(tty)").log"
-DTS_LOG_FILE="/tmp/dts_$(basename "$(tty)").log"
-DTS_VERBOSE_LOG_FILE="/tmp/dts-verbose_$(basename "$(tty)").log"
+DTS_LOG_FILE="$TMP_LOG_DIR/dts_$(basename "$(tty)").log"
+DTS_VERBOSE_LOG_FILE="$TMP_LOG_DIR/dts-verbose_$(basename "$(tty)").log"
 
 # shellcheck source=./logging
 source "$BASH_ENV"

--- a/scripts/dts-boot
+++ b/scripts/dts-boot
@@ -13,13 +13,13 @@ export DTS_SUBS="$SBIN_DIR/dts-subscription.sh"
 export DTS_HAL="$SBIN_DIR/dts-hal.sh"
 export DTS_MOCK_COMMON="$SBIN_DIR/common-mock-func.sh"
 export BASH_ENV="$SBIN_DIR/logging"
+export TMP_LOG_DIR="/tmp/logs"
 export ERR_LOG_FILE_REALPATH
 export DTS_LOG_FILE
 export DTS_VERBOSE_LOG_FILE
 export ERR_LOG_FILE
 export SHELLOPTS
 
-TMP_LOG_DIR="/tmp/logs"
 mkdir -p "$TMP_LOG_DIR"
 # $ERR_LOG_FILE is fd that can only be written to: '>()'. To copy logs
 # we need underlying file that can be copied

--- a/scripts/dts-boot
+++ b/scripts/dts-boot
@@ -19,6 +19,8 @@ export DTS_VERBOSE_LOG_FILE
 export ERR_LOG_FILE
 export SHELLOPTS
 
+# $ERR_LOG_FILE is fd that can only be written to: '>()'. To copy logs
+# we need underlying file that can be copied
 ERR_LOG_FILE_REALPATH="/var/local/dts-err_$(basename "$(tty)").log"
 DTS_LOG_FILE="/tmp/dts_$(basename "$(tty)").log"
 DTS_VERBOSE_LOG_FILE="/tmp/dts-verbose_$(basename "$(tty)").log"
@@ -28,6 +30,8 @@ source "$BASH_ENV"
 start_trace_logging
 start_logging
 if [ -z "$ERR_LOG_FILE" ]; then
+    # pass everything written to $ERR_LOG_FILE to logger function and save it's
+    # output to $ERR_LOG_FILE_REALPATH file
     exec {ERR_LOG_FILE}> >(logger >> "$ERR_LOG_FILE_REALPATH")
     ERR_LOG_FILE="/proc/$$/fd/$ERR_LOG_FILE"
 fi

--- a/scripts/dts-boot
+++ b/scripts/dts-boot
@@ -14,6 +14,16 @@ export DTS_SUBS="$SBIN_DIR/dts-subscription.sh"
 export DTS_HAL="$SBIN_DIR/dts-hal.sh"
 export DTS_MOCK_COMMON="$SBIN_DIR/common-mock-func.sh"
 export DTS_LOG_FILE="/tmp/dts.log"
+export DTS_VERBOSE_LOG_FILE="/tmp/dts-verbose.log"
+export BASH_ENV="/$SBIN_DIR/logging"
+export SHELLOPTS
+
+# shellcheck source=./logging
+source "$BASH_ENV"
+start_logging "$DTS_LOG_FILE"
+exec {xtrace_fd}>>"${DTS_VERBOSE_LOG_FILE}"
+export BASH_XTRACEFD=${xtrace_fd}
+set -x
 
 # shellcheck source=../include/dts-environment.sh
 source $DTS_ENV
@@ -25,5 +35,5 @@ source $DTS_HAL
 if [ -f $FUM_EFIVAR ]; then
     $SBIN_DIR/dasharo-deploy update fum
 else
-    $BIN_DIR/script -c $SBIN_DIR/dts "$DTS_LOG_FILE"
+    $SBIN_DIR/dts
 fi

--- a/scripts/dts-boot
+++ b/scripts/dts-boot
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SBIN_DIR="/usr/sbin"
-BIN_DIR="/usr/bin"
 FUM_EFIVAR="/sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359"
 
 export DTS_FUNCS="$SBIN_DIR/dts-functions.sh"

--- a/scripts/dts-boot
+++ b/scripts/dts-boot
@@ -13,17 +13,18 @@ export DTS_ENV="$SBIN_DIR/dts-environment.sh"
 export DTS_SUBS="$SBIN_DIR/dts-subscription.sh"
 export DTS_HAL="$SBIN_DIR/dts-hal.sh"
 export DTS_MOCK_COMMON="$SBIN_DIR/common-mock-func.sh"
-export DTS_LOG_FILE="/tmp/dts.log"
-export DTS_VERBOSE_LOG_FILE="/tmp/dts-verbose.log"
-export BASH_ENV="/$SBIN_DIR/logging"
+export DTS_LOG_FILE
+export DTS_VERBOSE_LOG_FILE
+export BASH_ENV="$SBIN_DIR/logging"
 export SHELLOPTS
+
+DTS_LOG_FILE="/tmp/dts_$(basename "$(tty)").log"
+DTS_VERBOSE_LOG_FILE="/tmp/dts-verbose_$(basename "$(tty)").log"
 
 # shellcheck source=./logging
 source "$BASH_ENV"
-start_logging "$DTS_LOG_FILE"
-exec {xtrace_fd}>>"${DTS_VERBOSE_LOG_FILE}"
-export BASH_XTRACEFD=${xtrace_fd}
-set -x
+start_trace_logging "${DTS_VERBOSE_LOG_FILE}"
+start_logging "${DTS_LOG_FILE}"
 
 # shellcheck source=../include/dts-environment.sh
 source $DTS_ENV

--- a/scripts/dts-boot
+++ b/scripts/dts-boot
@@ -13,18 +13,25 @@ export DTS_ENV="$SBIN_DIR/dts-environment.sh"
 export DTS_SUBS="$SBIN_DIR/dts-subscription.sh"
 export DTS_HAL="$SBIN_DIR/dts-hal.sh"
 export DTS_MOCK_COMMON="$SBIN_DIR/common-mock-func.sh"
+export BASH_ENV="$SBIN_DIR/logging"
+export ERR_LOG_FILE_REALPATH
 export DTS_LOG_FILE
 export DTS_VERBOSE_LOG_FILE
-export BASH_ENV="$SBIN_DIR/logging"
+export ERR_LOG_FILE
 export SHELLOPTS
 
+ERR_LOG_FILE_REALPATH="/var/local/dts-err_$(basename "$(tty)").log"
 DTS_LOG_FILE="/tmp/dts_$(basename "$(tty)").log"
 DTS_VERBOSE_LOG_FILE="/tmp/dts-verbose_$(basename "$(tty)").log"
 
 # shellcheck source=./logging
 source "$BASH_ENV"
-start_trace_logging "${DTS_VERBOSE_LOG_FILE}"
-start_logging "${DTS_LOG_FILE}"
+start_trace_logging
+start_logging
+if [ -z "$ERR_LOG_FILE" ]; then
+    exec {ERR_LOG_FILE}> >(logger >> "$ERR_LOG_FILE_REALPATH")
+    ERR_LOG_FILE="/proc/$$/fd/$ERR_LOG_FILE"
+fi
 
 # shellcheck source=../include/dts-environment.sh
 source $DTS_ENV

--- a/scripts/logging
+++ b/scripts/logging
@@ -20,7 +20,7 @@ start_logging() {
 
 stop_logging() {
     if [ -n "$LOGGING" ]; then
-        exec &>"$(tty)"
+        exec >&0
         LOGGING=
     fi
 }

--- a/scripts/logging
+++ b/scripts/logging
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+logger() {
+    while read -r LINE
+    do
+        echo "[$(date +%T.%3N)]: $LINE"
+    done
+}
+
 start_logging() {
     local file="$DTS_LOG_FILE"
     if [ -z "$LOGGING" ]; then

--- a/scripts/logging
+++ b/scripts/logging
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+start_logging() {
+    local file=$1
+    CURRENT_TTY="$(tty)"
+    exec 1>> >(tee >(stdbuf -i0 -oL -eL ts "[%T]: " >> "$file")) 2>&1
+}
+
+stop_logging() {
+    exec &>"$CURRENT_TTY"
+}
+
+export PS4="+[\$(date +%T.%3N)]:\${BASH_SOURCE[0]}:\${LINENO[0]}:\${FUNCNAME[0]:-main}: "
+export CURRENT_TTY

--- a/scripts/logging
+++ b/scripts/logging
@@ -2,13 +2,38 @@
 
 start_logging() {
     local file=$1
-    CURRENT_TTY="$(tty)"
-    exec 1>> >(tee >(stdbuf -i0 -oL -eL ts "[%T]: " >> "$file")) 2>&1
+    if [ -z "$LOGGING" ]; then
+        LOGGING="Y"
+        if [ -z "$DESC" ]; then
+            exec {DESC}> >(tee >(stdbuf -i0 -oL -eL ts "[%T]: " >> "$file"))
+        fi
+        exec 1>&$DESC
+    fi
 }
 
 stop_logging() {
-    exec &>"$CURRENT_TTY"
+    if [ -n "$LOGGING" ]; then
+        exec &>"$(tty)"
+        LOGGING=
+    fi
+}
+
+start_trace_logging() {
+    local file=$1
+    if [ -z "$BASH_XTRACEFD" ]; then
+        exec {xtrace_fd}>>"$file"
+        export BASH_XTRACEFD=${xtrace_fd}
+        set -x
+    fi
+}
+
+stop_trace_logging() {
+    if [ -n "$BASH_XTRACEFD" ]; then
+        set +x
+        BASH_XTRACEFD=
+    fi
 }
 
 export PS4="+[\$(date +%T.%3N)]:\${BASH_SOURCE[0]}:\${LINENO[0]}:\${FUNCNAME[0]:-main}: "
-export CURRENT_TTY
+export LOGGING
+export DESC

--- a/scripts/logging
+++ b/scripts/logging
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 start_logging() {
-    local file=$1
+    local file="$DTS_LOG_FILE"
     if [ -z "$LOGGING" ]; then
         LOGGING="Y"
         if [ -z "$DESC" ]; then
@@ -19,7 +19,7 @@ stop_logging() {
 }
 
 start_trace_logging() {
-    local file=$1
+    local file="$DTS_VERBOSE_LOG_FILE"
     if [ -z "$BASH_XTRACEFD" ]; then
         exec {xtrace_fd}>>"$file"
         export BASH_XTRACEFD=${xtrace_fd}

--- a/scripts/logging
+++ b/scripts/logging
@@ -10,8 +10,10 @@ logger() {
 start_logging() {
     local file="$DTS_LOG_FILE"
     if [ -z "$LOGGING" ]; then
-        LOGGING="Y"
+        LOGGING="true"
         if [ -z "$DESC" ]; then
+            # Create file descriptor that echoes back anything written to it
+            # and also logs that line to file with added timestamp prefix
             exec {DESC}> >(tee >(stdbuf -i0 -oL -eL ts "[%T]: " >> "$file"))
         fi
         exec 1>&$DESC


### PR DESCRIPTION
* /tmp/dts.log

    ```
    [01:41:55]:  [H[J[3Jc[0m
    [01:41:55]:   Dasharo Tools Suite Script 2.1.0 [0m
    [01:41:55]:  [0m (c) Dasharo <contact@dasharo.com> [0m
    [01:41:55]:  [0m Report issues at: https://github.com/Dasharo/dasharo-issues [0m
    [01:41:55]:  [0;36m*********************************************************[0m
    [01:41:55]:  [0;36m**[0m                HARDWARE INFORMATION [0m
    [01:41:55]:  [0;36m*********************************************************[0m
    ```

* /tmp/dts-verbose.log

    ```
    +[02:05:44.047]:/usr/sbin/dts-boot:29:main: source /usr/sbin/dts-environment.sh
    ++[02:05:44.048]:/usr/sbin/dts-environment.sh:9:main: source /usr/sbin/dts-hal.sh
    +++[02:05:44.049]:/usr/sbin/dts-hal.sh:25:main: source /usr/sbin/common-mock-func.sh
    ++++[02:05:44.050]:/usr/sbin/common-mock-func.sh:53:main: TEST_FLASH_LOCK=
    ++++[02:05:44.050]:/usr/sbin/common-mock-func.sh:54:main: TEST_BOARD_HAS_FD_REGION=true
    ++++[02:05:44.050]:/usr/sbin/common-mock-func.sh:55:main: TEST_BOARD_FD_REGION_RW=true
    ++++[02:05:44.051]:/usr/sbin/common-mock-func.sh:56:main: TEST_BOARD_HAS_ME_REGION=true
    ++++[02:05:44.051]:/usr/sbin/common-mock-func.sh:57:main: TEST_BOARD_ME_REGION_RW=true
    ```

When entering shell, logging to `dts.log` is disabled as redirecting output results in problems in interactive shell but verbose (xtrace) logs are still enabled just without timestamp:

```
+ echo /root/.vim/after/scripts.vim
+ shift
+ '[' 0 -ge 1 ']'
+ tail /tmp/dts-verbose.log
+ clear
+ ls
+ cp ../tmp/dts-verbose.log ../tmp/dts.log .
```

After returning to DTS UI by using `exit` normal logging is enabled again and verbose logs contain timestamp 

There is one problem, trying to enter `dts-boot` second time from shell results in error

```
/usr/sbin/dts: line 41: read: error setting terminal attributes: Interrupted system call
```

after which we end up back in shell.

@PLangowski what do you think?