### PR TITLE
check_for_dasharo_firmware: fix checking for creds file

### DIFF
--- a/include/dts-subscription.sh
+++ b/include/dts-subscription.sh
@@ -12,7 +12,7 @@ check_for_dasharo_firmware() {
 
   echo "Checking for Dasharo firmware..."
 
-  if [ -f "$DPP_CREDENTIAL_FILE" ]; then
+  if ! [ -f "$DPP_CREDENTIAL_FILE" ]; then
     print_warning "No credentials provided, cannot check for Dasharo firmware access."
     return 1
   fi


### PR DESCRIPTION
Fix issues met during 2.1.2 release: https://github.com/Dasharo/meta-dts/actions/runs/12434149601.