### PR TITLE
Optimize hcl report execution time.

### DIFF
--- a/include/hal/common-mock-func.sh
+++ b/include/hal/common-mock-func.sh
@@ -406,6 +406,7 @@ TEST_TOUCHPAD_PATH="${TEST_TOUCHPAD_PATH:-}"
 TEST_AC_PRESENT="${TEST_AC_PRESENT:-}"
 TEST_MEI_CONF_PRESENT="${TEST_MEI_CONF_PRESENT:-true}"
 TEST_INTEL_FUSE_STATUS="${TEST_INTEL_FUSE_STATUS:-0}"
+TEST_SOUND_CARD_PRESENT="${TEST_SOUND_CARD_PRESENT:-true}"
 
 fsread_tool_common_mock(){
 # This functionn emulates read hardware specific file system resources or its
@@ -443,6 +444,11 @@ fsread_tool_test_mock(){
   if [ "$_arg_e" = "/sys/class/power_supply/AC/online" ]; then
   # Emulating AC status file presence, check check_if_ac func. for more inf.:
     [ "$TEST_AC_PRESENT" = "true" ] && return 0
+  fi
+
+  if [ "$_arg_f" = "/sys/class/sound/card0/hw*/init_pin_configs" ] || [ "$_arg_f" = "/proc/asound/card0/codec#*" ]; then
+  # Emulate sound card presence, check dasharo-hcl-report for more inf.:
+    [ "$TEST_SOUND_CARD_PRESENT" = "true" ] && return 0
   fi
 
   return 1

--- a/include/hal/dts-hal.sh
+++ b/include/hal/dts-hal.sh
@@ -181,7 +181,7 @@ cap_upd_tool(){
 
 check_if_heci_present(){
 # FIXME: what if HECI is not device 16.0?
-  $FSREAD_TOOL test_mock test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0
+  $FSREAD_TOOL test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0
 
   return $?
 }

--- a/reports/dasharo-hcl-report
+++ b/reports/dasharo-hcl-report
@@ -141,7 +141,7 @@ do
   SND_HW_FILE=`echo $SND_HW_FILES | cut -d ' ' -f 1`
   SND_CODEC_FILE=`echo $SND_CODEC_FILES | cut -d ' ' -f 1`
 
-  if [ -f "$SND_HW_FILE" ] && [ -f "$SND_CODEC_FILE" ]; then
+  if  $FSREAD_TOOL test -f "$SND_HW_FILE" && $FSREAD_TOOL test -f "$SND_CODEC_FILE"; then
     break
   else
     sleep 5


### PR DESCRIPTION
Related issue: https://github.com/Dasharo/open-source-firmware-validation/issues/652.

Results:

Without https://github.com/Dasharo/open-source-firmware-validation/pull/658 and this PR:

```bash
λ time robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v dpp_logs_key:'x' -v dpp_download_key:'x' -v dpp_password:'x' -v boot_dts_from_ipxe_shell:True -v dts_ipxe_link:http://192.168.4.175:8080/ipxe -i msi_dpp dts/dts-e2e.robot
==============================================================================
Dts-E2E                                                                       
==============================================================================
E2E003.003 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Core... | PASS |
------------------------------------------------------------------------------
E2E003.004 MSI PRO Z690-A initial deployment (legacy -> Coreboot +... | PASS |
------------------------------------------------------------------------------
E2E003.005 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Core... | PASS |
------------------------------------------------------------------------------
E2E003.006 MSI PRO Z690-A initial deployment (legacy -> Coreboot +... | PASS |
------------------------------------------------------------------------------
E2E003.009 MSI PRO Z690-A DDR-4 update (Coreboot + UEFI -> Coreboo... | PASS |
------------------------------------------------------------------------------
E2E003.010 MSI PRO Z690-A update (Coreboot + UEFI -> Coreboot + UE... | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
Debug:   /home/danillklimuk/Projects/DTS/open-source-firmware-validation/command_log.txt
Output:  /home/danillklimuk/Projects/DTS/open-source-firmware-validation/output.xml
Log:     /home/danillklimuk/Projects/DTS/open-source-firmware-validation/log.html
Report:  /home/danillklimuk/Projects/DTS/open-source-firmware-validation/report.html
robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v  -v  -v  -v 
284.90s user 3.05s system 23% cpu 20:12.88 total
```

Without this PR:

```bash
λ time robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v dpp_logs_key:'x' -v dpp_download_key:'x' -v dpp_password:'x' -v boot_dts_from_ipxe_shell:True -v dts_ipxe_link:http://192.168.4.175:8080/ipxe -i msi_dpp dts/dts-e2e.robot
==============================================================================
Dts-E2E                                                                       
==============================================================================
E2E003.003 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Core... | PASS |
------------------------------------------------------------------------------
E2E003.004 MSI PRO Z690-A initial deployment (legacy -> Coreboot +... | PASS |
------------------------------------------------------------------------------
E2E003.005 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Core... | PASS |
------------------------------------------------------------------------------
E2E003.006 MSI PRO Z690-A initial deployment (legacy -> Coreboot +... | PASS |
------------------------------------------------------------------------------
E2E003.009 MSI PRO Z690-A DDR-4 update (Coreboot + UEFI -> Coreboo... | PASS |
------------------------------------------------------------------------------
E2E003.010 MSI PRO Z690-A update (Coreboot + UEFI -> Coreboot + UE... | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
Debug:   /home/danillklimuk/Projects/DTS/open-source-firmware-validation/command_log.txt
Output:  /home/danillklimuk/Projects/DTS/open-source-firmware-validation/output.xml
Log:     /home/danillklimuk/Projects/DTS/open-source-firmware-validation/log.html
Report:  /home/danillklimuk/Projects/DTS/open-source-firmware-validation/report.html
robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v  -v  -v  -v 
51.44s user 1.94s system 10% cpu 8:10.60 total
```

With both PRs:

```bash
λ time robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v dpp_logs_key:'x' -v dpp_download_key:'x' -v dpp_password:'x' -v boot_dts_from_ipxe_shell:True -v dts_ipxe_link:http://192.168.4.175:8080/ipxe -i msi_dpp dts/dts-e2e.robot
==============================================================================
Dts-E2E                                                                       
==============================================================================
E2E003.003 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Core... | PASS |
------------------------------------------------------------------------------
E2E003.004 MSI PRO Z690-A initial deployment (legacy -> Coreboot +... | PASS |
------------------------------------------------------------------------------
E2E003.005 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Core... | PASS |
------------------------------------------------------------------------------
E2E003.006 MSI PRO Z690-A initial deployment (legacy -> Coreboot +... | PASS |
------------------------------------------------------------------------------
E2E003.009 MSI PRO Z690-A DDR-4 update (Coreboot + UEFI -> Coreboo... | PASS |
------------------------------------------------------------------------------
E2E003.010 MSI PRO Z690-A update (Coreboot + UEFI -> Coreboot + UE... | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
Debug:   /home/danillklimuk/Projects/DTS/open-source-firmware-validation/command_log.txt
Output:  /home/danillklimuk/Projects/DTS/open-source-firmware-validation/output.xml
Log:     /home/danillklimuk/Projects/DTS/open-source-firmware-validation/log.html
Report:  /home/danillklimuk/Projects/DTS/open-source-firmware-validation/report.html
robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v  -v  -v  -v
 35.97s user 1.03s system 14% cpu 4:07.11 total
```