### PR TITLE
Make functions in HCL Report not to exit

### DIFF
--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -713,9 +713,11 @@ check_flash_chip() {
       fi
     done
     if [ -z "$FLASH_CHIP_SELECT" ]; then
-      error_exit "No supported chipset found, exit."
+      return 1
     fi
   fi
+
+  return 0
 }
 
 compare_versions() {

--- a/reports/touchpad-info
+++ b/reports/touchpad-info
@@ -22,8 +22,8 @@ path=$($FSREAD_TOOL cat "/sys/bus/i2c/devices/$devname/firmware_node/path")
 ACPI_CALL_PATH="/proc/acpi/call"
 
 if [ ! -f "$ACPI_CALL_PATH" ]; then
-   echo "File ${ACPI_CALL_PATH} doesn\'t exist. Exiting"
-   exit 3
+   echo "File ${ACPI_CALL_PATH} doesn\'t exist..."
+   return 3
 fi
 
 echo "$path._DSM bF7F6DF3C67425545AD05B30A3D8938DE 1 1" > ${ACPI_CALL_PATH}

--- a/scripts/dasharo-deploy
+++ b/scripts/dasharo-deploy
@@ -1218,7 +1218,7 @@ if [ "${SYSTEM_VENDOR}" != "QEMU" ] && [ "${SYSTEM_VENDOR}" != "Emulation" ]; th
   # Size of flashchip should be checked before board_config func. because the
   # func. assigns some configs based on the chip size detected for ASUS boards
   # (FIXME).
-  check_flash_chip
+  check_flash_chip || error_exit "No supported chipset found, exit."
 fi
 
 board_config


### PR DESCRIPTION
HCL report collects information, if smth is missing or not working - it still should be collected by HCL report. Therefore there should be no exit on error inside HCL report.

I went manually through HCL Report and modified all functions that used `exit` to use `return`. So, now the functions will report error but will not exit.