### PR TITLE
Hide DPP credentials by default

### DIFF
--- a/include/dts-environment.sh
+++ b/include/dts-environment.sh
@@ -50,6 +50,8 @@ SSH_OPT_UP="K"
 SSH_OPT_LOW="$(echo $SSH_OPT_UP | awk '{print tolower($0)}')"
 SEND_LOGS_OPT="L"
 SEND_LOGS_OPT_LOW="$(echo $SEND_LOGS_OPT | awk '{print tolower($0)}')"
+TOGGLE_DISP_CRED_OPT_UP="C"
+TOGGLE_DISP_CRED_OPT_LOW="$(echo $TOGGLE_DISP_CRED_OPT_UP | awk '{print tolower($0)}')"
 
 # Hardware variables:
 SYSTEM_VENDOR="$($DMIDECODE dump_var_mock -s system-manufacturer)"

--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1332,9 +1332,15 @@ show_dpp_credentials() {
   if [ -n "${DPP_IS_LOGGED}" ]; then
     echo -e "${BLUE}**${NORMAL}                DPP credentials ${NORMAL}"
     echo -e "${BLUE}*********************************************************${NORMAL}"
-    echo -e "${BLUE}**${YELLOW}       Logs key: ${NORMAL}${CLOUDSEND_LOGS_URL}"
-    echo -e "${BLUE}**${YELLOW}   Download key: ${NORMAL}${CLOUDSEND_DOWNLOAD_URL}"
-    echo -e "${BLUE}**${YELLOW}       Password: ${NORMAL}${CLOUDSEND_PASSWORD}"
+    if [ "${DISPLAY_CREDENTIALS}" == "true" ]; then
+      echo -e "${BLUE}**${YELLOW}       Logs key: ${NORMAL}${CLOUDSEND_LOGS_URL}"
+      echo -e "${BLUE}**${YELLOW}   Download key: ${NORMAL}${CLOUDSEND_DOWNLOAD_URL}"
+      echo -e "${BLUE}**${YELLOW}       Password: ${NORMAL}${CLOUDSEND_PASSWORD}"
+    else
+      echo -e "${BLUE}**${YELLOW}       Logs key: ${NORMAL}***************"
+      echo -e "${BLUE}**${YELLOW}   Download key: ${NORMAL}***************"
+      echo -e "${BLUE}**${YELLOW}       Password: ${NORMAL}***************"
+    fi
     echo -e "${BLUE}*********************************************************${NORMAL}"
   fi
 }
@@ -1567,6 +1573,13 @@ show_footer(){
   else
     echo -e "${RED}${SEND_LOGS_OPT}${NORMAL} to enable sending DTS logs ${NORMAL}"
   fi
+  if [ -n "${DPP_IS_LOGGED}" ]; then
+    if [ "${DISPLAY_CREDENTIALS}" == "true" ]; then
+      echo -e "${RED}${TOGGLE_DISP_CRED_OPT_UP}${NORMAL} to hide DPP credentials ${NORMAL}"
+    else
+      echo -e "${RED}${TOGGLE_DISP_CRED_OPT_UP}${NORMAL} to display DPP credentials ${NORMAL}"
+    fi
+  fi
   echo -ne "${YELLOW}\nEnter an option:${NORMAL}"
 }
 
@@ -1617,6 +1630,13 @@ footer_options(){
         unset SEND_LOGS_ACTIVE
       else
         export SEND_LOGS_ACTIVE="true"
+      fi
+      ;;
+    "${TOGGLE_DISP_CRED_OPT_UP}" | "${TOGGLE_DISP_CRED_OPT_LOW}")
+      if [ "${DISPLAY_CREDENTIALS}" == "true" ]; then
+        unset DISPLAY_CREDENTIALS
+      else
+        export DISPLAY_CREDENTIALS="true"
       fi
       ;;
   esac


### PR DESCRIPTION
Displaying credentials risks accidental exposure. Hide credentials by default and add toggle option to display them.