### PR TITLE
scripts: fix double ME flashing dialog

### DIFF
--- a/scripts/dasharo-deploy
+++ b/scripts/dasharo-deploy
@@ -749,7 +749,6 @@ firmware_pre_updating_routine(){
   check_blobs_in_binary $BIOS_UPDATE_FILE
   check_if_me_disabled
   set_flashrom_update_params $BIOS_UPDATE_FILE
-  set_intel_regions_update_params "-N --ifd"
   check_vboot_keys
 
   return 0
@@ -832,6 +831,7 @@ deploy_firmware(){
       $FLASHROM -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} ${FLASHROM_ADD_OPT_UPDATE_OVERRIDE} -w "$BIOS_UPDATE_FILE"  >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
       error_check "Failed to update Dasharo firmware"
     else
+      set_intel_regions_update_params "-N --ifd"
       $FLASHROM -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} ${FLASHROM_ADD_OPT_UPDATE} -w "$BIOS_UPDATE_FILE"  >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
       error_check "Failed to update Dasharo firmware"
 


### PR DESCRIPTION
During attempt to update Dasharo via DTS user is asked twice to skip ME flashing. Move `set_intel_regions_update_params()` call from `firmware_pre_updating_routine()` to the "else" part of the "if" statement after `firmware_pre_updating_routine()` call so it is not executed twice.