### PR TITLE
dts-hal.sh: generate tool call profile

### DIFF
--- a/include/hal/dts-hal.sh
+++ b/include/hal/dts-hal.sh
@@ -130,14 +130,17 @@ tool_wrapper() {
     else
       common_mock $_tool
     fi
-
-    return $?
+  else
+    # If not testing - call tool with the arguments instead:
+    $_tool "${_arguments[@]}"
   fi
+  # !! When modifying this function, make sure this is return value of wrapped
+  # tool (real of mocked)
+  ret=$?
+  echo "${_tool} ${_arguments[*]} $ret" >>/tmp/logs/profile
+  echo "${BASH_SOURCE[1]}:${FUNCNAME[1]} ${_tool} ${_arguments[*]} $ret" >>/tmp/logs/debug_profile
 
-  # If not testing - call tool with the arguments instead:
-  $_tool "${_arguments[@]}"
-
-  return $?
+  return $ret
 }
 
 ################################################################################


### PR DESCRIPTION
Profil wygenerowany dla emulowanego `Notebook NS5x_NS7xPU`

```sh
# cat /tmp/logs/profile
dmidecode -s system-manufacturer 0
dmidecode -s system-product-name 0
dmidecode -s baseboard-product-name 1
dmidecode -s processor-version 1
dmidecode -s bios-vendor 0
dmidecode -s bios-version 0
dmidecode -s system-manufacturer 0
dmidecode -s system-product-name 0
dmidecode -s baseboard-product-name 1
dmidecode -s processor-version 1
dmidecode -s bios-vendor 0
dmidecode -s bios-version 0
dmidecode  0
fsread_tool test -d /sys/firmware/efi 0
dmidecode -s system-manufacturer 0
dmidecode -s system-product-name 0
dmidecode -s baseboard-product-name 1
dmidecode -s processor-version 1
dmidecode -s bios-vendor 0
dmidecode -s bios-version 0
flashrom -p internal --flash-name 0
flashrom -p internal --flash-size 0
fsread_tool test -e /sys/class/power_supply/AC/online 1
flashrom -p internal 0
dasharo_ectool info 0
flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 0
dcu logo /tmp/biosupdate -l /tmp/logo.bmp 0
cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
flashrom -p internal 0
ifdtool -d /tmp/biosupdate 0
fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
cbfstool /tmp/bios.bin layout -w 0
cbfstool /tmp/biosupdate layout -w 0
flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
dasharo_ectool flash /tmp/ecupdate 0
reboot  0
dmidecode  0
fsread_tool test -d /sys/firmware/efi 0
```

Ostatnie 2 linijki możliwe, że trzeba będzie wyciąć, ponieważ na realnym systemie po `reboot` już chyba nic się nie pojawi.