### PR TITLE
Add global flag to show msg 'Waiting for network connection...' only once

### DIFF
--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -185,7 +185,7 @@ NETWORK_WAIT_MSG_SHOWN=false
 wait_for_network_connection() {
   # if first argument equals true then print warning else print error
   local print_warning="$1"
-  n="10" 
+  n="10"
 
   if [ "$NETWORK_WAIT_MSG_SHOWN" = false ]; then
     echo 'Waiting for network connection ...'


### PR DESCRIPTION
The first time the function is called, the message will be displayed. Subsequent calls will no longer show it until the script finishes or the flag is manually reset (NETWORK_WAIT_MSG_SHOWN=false).