### PR TITLE
include: dts-functions.sh: sync_clocks before dumping and sending HCL

### DIFF
--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -1116,7 +1116,9 @@ main_menu_options() {
       # dts scripting should get some LOGLEVEL and maybe dumping working
       # logs to file
       export DEPLOY_REPORT="false"
-      wait_for_network_connection && ${CMD_DASHARO_HCL_REPORT} && LOGS_SENT="1"
+      wait_for_network_connection &&
+        sync_clocks &&
+        ${CMD_DASHARO_HCL_REPORT} && LOGS_SENT="1"
     else
       export DEPLOY_REPORT="false"
       ${CMD_DASHARO_HCL_REPORT}


### PR DESCRIPTION
If clocks are not synced the "mc" might fail with the following log:

```
mc: <ERROR> Unable to initialize new alias from the provided credentials. The difference between the request time and the server'\''s time is too large.
```

And the HCL will not be sent.