### PR TITLE
fix(dts): remove duplicate network wait prompt in deploy workflows

### DIFF
--- a/include/dts-functions.sh
+++ b/include/dts-functions.sh
@@ -275,13 +275,8 @@ board_config() {
   # set. This is made with a goal to limit global variables declaration to
   # dts-environment.sh and board_config function.
 
-  # We download firmwares via network. At this point, the network connection
-  # must be up already.
-
-  if ! wait_for_network_connection true; then
-    FETCH_LOCALLY="true"
-    print_warning "DTS couldn't connect to the internet! Using local files instead."
-  fi
+  # board_config should not force a network check globally.
+  # Connection checks are handled at concrete download points in workflows.
 
   mkdir -p "$BOARD_CONFIG_PATH"
   if [ "$FETCH_LOCALLY" = "true" ]; then

--- a/scripts/dasharo-deploy.sh
+++ b/scripts/dasharo-deploy.sh
@@ -1226,6 +1226,8 @@ install_workflow() {
   check_if_cpu_compatible
 
   # Download and verify firmware:
+  wait_for_network_connection true
+
   if [ "$HAVE_EC" == "true" ]; then
     download_ec
     verify_artifacts ec
@@ -1309,6 +1311,8 @@ update_workflow() {
   if [ "$FIRMWARE_VERSION" == "community_cap" ] || [ "$FIRMWARE_VERSION" == "dpp_cap" ]; then
     fum_and_capsule_check
   fi
+
+  wait_for_network_connection true
 
   if [ "$HAVE_EC" == "true" ]; then
     download_ec
@@ -1619,6 +1623,7 @@ restore() {
       echo
       echo "Searching for HCL report on cloud..."
 
+      wait_for_network_connection true
       ${CMD_CLOUD_LIST} $uuid
       error_check "Could not download HCL report from cloud."
 


### PR DESCRIPTION
## Summary\n- remove early network wait check from  to avoid duplicated prompt\n- run  at concrete download points in  and \n- add network check before cloud HCL lookup in \n\n## Why\nIssue #1219 reports repeated "Waiting for network connection" message.\n\n## Validation\n- syntax check: \n- reviewed flow to keep download-time checks in deploy paths\n\nCloses Dasharo/dasharo-issues#1219