### PR TITLE
build: support DTS_CONFIGS_REF override during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@
 
 SBINDIR ?= /usr/sbin
 SYSCONFDIR ?= /etc
+DTS_CONFIGS_REF ?= refs/heads/main
 
 install:
 	install -d $(DESTDIR)$(SBINDIR)
 
 	install -m 0755 include/dts-environment.sh $(DESTDIR)$(SBINDIR)
+	sed -i "s|refs/heads/main|$(DTS_CONFIGS_REF)|g" $(DESTDIR)$(SBINDIR)/dts-environment.sh
 	install -m 0755 include/dts-functions.sh $(DESTDIR)$(SBINDIR)
 	install -m 0755 include/dts-subscription.sh $(DESTDIR)$(SBINDIR)
 	install -m 0755 include/hal/dts-hal.sh $(DESTDIR)$(SBINDIR)


### PR DESCRIPTION
## Summary
Allow overriding DTS configs ref in `dts-environment.sh` during installation.

## Changes
- Add `DTS_CONFIGS_REF ?= refs/heads/main` to `Makefile`
- During `install`, patch installed `dts-environment.sh` with `$(DTS_CONFIGS_REF)`

## Why
This enables downstream (e.g., `meta-dts`) to keep stable default (`main`) while selecting `develop` in nightly via build-time variable, without duplicating replacement logic in recipes.
